### PR TITLE
titan: Set lower volume incall

### DIFF
--- a/configs/mixer_paths.xml
+++ b/configs/mixer_paths.xml
@@ -350,6 +350,7 @@
 		<ctl name="SLIM_0_RX Channels" value="One" />
 		<ctl name="RX1 MIX1 INP1" value="RX1" />
 		<ctl name="CLASS_H_DSM MUX" value="RX_HPHL" />
+		<ctl name="RX1 Digital Volume" value="60" />
 		<ctl name="RDAC3 MUX" value="DEM2" />
 		<ctl name="EAR PA Gain" value="POS_6_DB" />
 		<ctl name="DAC1 Switch" value="1" />


### PR DESCRIPTION
For some reason volume is really too loud and distorted, 60 seems to be safe value.

Change-Id: I9d9d0d06501f7630c2b91f3caeadfb84ba63fd25